### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -56,7 +56,7 @@ class syntax_plugin_datasearchform extends DokuWiki_Syntax_Plugin {
      * @param   Doku_Handler $handler Reference to the Doku_Handler object
      * @return  array Return an array with all data you want to use in render
      */
-    public function handle($match, $state, $pos, &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = trim(substr($match,15,-1)); //strip {datasearchform (length 15) from start and } from end
         list($key,$value) = explode('=', $match, 2);
 
@@ -76,7 +76,7 @@ class syntax_plugin_datasearchform extends DokuWiki_Syntax_Plugin {
      * @param   $data     array         data created by handler()
      * @return  boolean                 rendered correctly?
      */
-    public function render($format, &$renderer, $data) {
+    public function render($format, Doku_Renderer $renderer, $data) {
         global $lang, $INFO, $ACT, $QUERY;
 
         if($format == 'xhtml') {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
